### PR TITLE
Fixed the issue where the peer currently in the banned state is a negative number.

### DIFF
--- a/src/components/statisticInfo.vue
+++ b/src/components/statisticInfo.vue
@@ -38,8 +38,8 @@
         <a-grid-item class="panel-col" :span="{ xs: 12, sm: 12, md: 6 }">
           <a-statistic
             title="当前处于封禁状态Peer"
-            :value="(data?.peerBanCounter ?? 0) - (data?.peerUnbanCounter ?? 0)"
-            :value-from="(data?.peerBanCounter ?? 0) - (data?.peerUnbanCounter ?? 0)"
+            :value="peerBanStatus"
+            :value-from="peerBanStatus"
             animation
             show-group-separator
           >
@@ -64,4 +64,11 @@ const { data, refresh } = useRequest(getStatistic, {
 })
 
 watch(() => endpointStore.endpoint, refresh)
+
+const peerBanStatus = computed(() => {
+  const banCount = data.value?.peerBanCounter ?? 0
+  const unbanCount = data.value?.peerUnbanCounter ?? 0
+  const calculatedValue = banCount - unbanCount
+  return calculatedValue < 0 ? banCount : calculatedValue
+})
 </script>


### PR DESCRIPTION
Fixed the issue where the peer currently in the banned state is a negative number.The bug can be reproduced when the number of unblocked peers is greater than the number of blocked peers (for example, waiting for all nodes to be unblocked before restarting PBH). 
修复当前处于封禁状态Peer为负数的问题，当解封peer数量大于封禁数量时可复现bug（例如：等待所有节点解封后重新启动PBH）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the calculation for displaying peer ban status in the statistics component to ensure the value is always non-negative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->