### PR TITLE
add deluge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbh-fe",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/api/model/clientStatus.ts
+++ b/src/api/model/clientStatus.ts
@@ -15,6 +15,7 @@ export enum ClientTypeEnum {
   qBittorrent = 'qbittorrent',
   Transmission = 'transmission',
   BiglyBT = 'biglybt',
+  Deluge = 'deluge',
   Unknown = 'Unknown'
 }
 
@@ -31,7 +32,7 @@ export interface Torrent {
   hash: string
 }
 
-export type downloaderConfig = qBittorrentConfig | transmissionConfig | biglybtConfig
+export type downloaderConfig = qBittorrentConfig | transmissionConfig | biglybtConfig | delugeConfig
 
 export interface qBittorrentConfig {
   type: ClientTypeEnum.qBittorrent
@@ -65,6 +66,16 @@ export interface biglybtConfig {
   token: string
   httpVersion: string
   verifySsl: boolean
+}
+
+export interface delugeConfig {
+  type: ClientTypeEnum.Deluge
+  endpoint: string
+  password: string
+  httpVersion: string
+  incrementBan: boolean
+  verifySsl: boolean
+  rpcUrl: string
 }
 
 export interface CreateDownloadRequest {

--- a/src/views/dashboard/components/editDownloaderModal.vue
+++ b/src/views/dashboard/components/editDownloaderModal.vue
@@ -1,6 +1,7 @@
 <template>
   <a-modal
     v-model:visible="showModal"
+    :mask-closable="false"
     :title="
       newItem ? t('page.dashboard.editModal.title.new') : t('page.dashboard.editModal.title.edit')
     "
@@ -103,7 +104,11 @@
           <a-input-password v-model="form.config.password" allow-clear></a-input-password>
         </a-form-item>
         <a-form-item field="config.rpcUrl" label="RPC URL" required>
-          <a-input v-model="form.config.rpcUrl" allow-clear></a-input>
+          <a-input
+            v-model="form.config.rpcUrl"
+            allow-clear
+            placeholder="/transmission/rpc"
+          ></a-input>
         </a-form-item>
         <a-form-item
           field="config.httpVersion"
@@ -174,7 +179,7 @@
           <a-input v-model="form.config.password" allow-clear></a-input>
         </a-form-item>
         <a-form-item field="config.rpcUrl" label="RPC URL" required>
-          <a-input v-model="form.config.rpcUrl" allow-clear></a-input>
+          <a-input v-model="form.config.rpcUrl" allow-clear placeholder="/json"></a-input>
         </a-form-item>
         <a-form-item
           field="config.incrementBan"

--- a/src/views/dashboard/components/editDownloaderModal.vue
+++ b/src/views/dashboard/components/editDownloaderModal.vue
@@ -102,7 +102,7 @@
         <a-form-item field="config.password" :label="t('page.dashboard.editModal.label.password')">
           <a-input-password v-model="form.config.password" allow-clear></a-input-password>
         </a-form-item>
-        <a-form-item field="config.rpcUrl" label="RPC URL">
+        <a-form-item field="config.rpcUrl" label="RPC URL" required>
           <a-input v-model="form.config.rpcUrl" allow-clear></a-input>
         </a-form-item>
         <a-form-item
@@ -173,8 +173,8 @@
         >
           <a-input v-model="form.config.password" allow-clear></a-input>
         </a-form-item>
-        <a-form-item field="config.rpcUrl" label="RPC URL">
-          <a-input v-model="form.config.rpcUrl" allow-clear default-value="/json"></a-input>
+        <a-form-item field="config.rpcUrl" label="RPC URL" required>
+          <a-input v-model="form.config.rpcUrl" allow-clear></a-input>
         </a-form-item>
         <a-form-item
           field="config.incrementBan"

--- a/src/views/dashboard/components/editDownloaderModal.vue
+++ b/src/views/dashboard/components/editDownloaderModal.vue
@@ -14,6 +14,7 @@
           <a-radio :value="ClientTypeEnum.qBittorrent">qBittorrent</a-radio>
           <a-radio :value="ClientTypeEnum.Transmission">Transmission</a-radio>
           <a-radio :value="ClientTypeEnum.BiglyBT">BiglyBT</a-radio>
+          <a-radio :value="ClientTypeEnum.Deluge">Deluge</a-radio>
         </a-radio-group>
         <template #extra v-if="form.config.type === ClientTypeEnum.BiglyBT">
           <i18n-t keypath="page.dashboard.editModal.biglybt">
@@ -135,6 +136,55 @@
         </a-form-item>
         <a-form-item field="config.token" label="Token" required>
           <a-input v-model="form.config.token" allow-clear></a-input>
+        </a-form-item>
+        <a-form-item
+          field="config.httpVersion"
+          :label="t('page.dashboard.editModal.label.httpVersion')"
+        >
+          <a-radio-group v-model="form.config.httpVersion">
+            <a-radio value="HTTP_1_1">1.1</a-radio>
+            <a-radio value="HTTP_2_0">2.0</a-radio>
+          </a-radio-group>
+          <template #extra
+            >{{ t('page.dashboard.editModal.label.httpVersion.description') }}
+          </template>
+        </a-form-item>
+        <a-form-item
+          field="config.verifySsl"
+          default-checked
+          :label="t('page.dashboard.editModal.label.verifySsl')"
+        >
+          <a-switch v-model="form.config.verifySsl" />
+        </a-form-item>
+      </div>
+      <!-- Deluge config block -->
+      <div v-else-if="form.config.type === ClientTypeEnum.Deluge">
+        <a-form-item
+          field="config.endpoint"
+          :label="t('page.dashboard.editModal.label.endpoint')"
+          :rules="[{ required: true, type: 'url' }]"
+        >
+          <a-input v-model="form.config.endpoint" allow-clear></a-input>
+        </a-form-item>
+        <a-form-item
+          field="config.password"
+          :label="t('page.dashboard.editModal.label.password')"
+          required
+        >
+          <a-input v-model="form.config.password" allow-clear></a-input>
+        </a-form-item>
+        <a-form-item field="config.rpcUrl" label="RPC URL">
+          <a-input v-model="form.config.rpcUrl" allow-clear default-value="/json"></a-input>
+        </a-form-item>
+        <a-form-item
+          field="config.incrementBan"
+          default-checked
+          :label="t('page.dashboard.editModal.label.incrementBan')"
+        >
+          <a-switch v-model="form.config.incrementBan" />
+          <template #extra>
+            {{ t('page.dashboard.editModal.label.incrementBan.description') }}</template
+          >
         </a-form-item>
         <a-form-item
           field="config.httpVersion"

--- a/src/views/dashboard/components/editDownloaderModal.vue
+++ b/src/views/dashboard/components/editDownloaderModal.vue
@@ -30,7 +30,7 @@
       <a-form-item field="name" :label="t('page.dashboard.editModal.label.name')" required>
         <a-input v-model="form.name" allow-clear />
       </a-form-item>
-      <component :is="formMap[form.config.type]" v-model="form.config" />
+      <component :is="formMap[form.config.type] as any" v-model="form.config" />
     </a-form>
   </a-modal>
 </template>

--- a/src/views/dashboard/components/editDownloaderModal.vue
+++ b/src/views/dashboard/components/editDownloaderModal.vue
@@ -30,200 +30,32 @@
       <a-form-item field="name" :label="t('page.dashboard.editModal.label.name')" required>
         <a-input v-model="form.name" allow-clear />
       </a-form-item>
-      <!-- qBittorrent config block -->
-      <div v-if="form.config.type === ClientTypeEnum.qBittorrent">
-        <a-form-item
-          field="config.endpoint"
-          :label="t('page.dashboard.editModal.label.endpoint')"
-          :rules="[{ required: true, type: 'url' }]"
-        >
-          <a-input v-model="form.config.endpoint" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.username" :label="t('page.dashboard.editModal.label.username')">
-          <a-input v-model="form.config.username" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.password" :label="t('page.dashboard.editModal.label.password')">
-          <a-input-password v-model="form.config.password" allow-clear></a-input-password>
-        </a-form-item>
-        <a-form-item>
-          <a-checkbox v-model="useBasicAuth">
-            {{ t('page.dashboard.editModal.label.useBasicAuth') }}</a-checkbox
-          >
-        </a-form-item>
-        <a-form-item v-if="useBasicAuth" :content-flex="false">
-          <a-form-item field="config.basicAuth.user" label="User">
-            <a-input v-model="form.config.basicAuth.user" />
-          </a-form-item>
-          <a-form-item field="config.basicAuth.pass" label="Pass">
-            <a-input-password v-model="form.config.basicAuth.pass" />
-          </a-form-item>
-        </a-form-item>
-        <a-form-item
-          field="config.httpVersion"
-          :label="t('page.dashboard.editModal.label.httpVersion')"
-        >
-          <a-radio-group v-model="form.config.httpVersion">
-            <a-radio value="HTTP_1_1">1.1</a-radio>
-            <a-radio value="HTTP_2_0">2.0</a-radio>
-          </a-radio-group>
-          <template #extra
-            >{{ t('page.dashboard.editModal.label.httpVersion.description') }}
-          </template>
-        </a-form-item>
-        <a-form-item
-          field="config.incrementBan"
-          default-checked
-          :label="t('page.dashboard.editModal.label.incrementBan')"
-        >
-          <a-switch v-model="form.config.incrementBan" />
-          <template #extra>
-            {{ t('page.dashboard.editModal.label.incrementBan.description') }}</template
-          >
-        </a-form-item>
-        <a-form-item
-          field="config.verifySsl"
-          default-checked
-          :label="t('page.dashboard.editModal.label.verifySsl')"
-        >
-          <a-switch v-model="form.config.verifySsl" />
-        </a-form-item>
-      </div>
-      <!-- Transmission config block -->
-      <div v-else-if="form.config.type === ClientTypeEnum.Transmission">
-        <a-form-item
-          field="config.endpoint"
-          :label="t('page.dashboard.editModal.label.endpoint')"
-          :rules="[{ required: true, type: 'url' }]"
-        >
-          <a-input v-model="form.config.endpoint" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.username" :label="t('page.dashboard.editModal.label.username')">
-          <a-input v-model="form.config.username" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.password" :label="t('page.dashboard.editModal.label.password')">
-          <a-input-password v-model="form.config.password" allow-clear></a-input-password>
-        </a-form-item>
-        <a-form-item field="config.rpcUrl" label="RPC URL" required>
-          <a-input
-            v-model="form.config.rpcUrl"
-            allow-clear
-            placeholder="/transmission/rpc"
-          ></a-input>
-        </a-form-item>
-        <a-form-item
-          field="config.httpVersion"
-          :label="t('page.dashboard.editModal.label.httpVersion')"
-        >
-          <a-radio-group v-model="form.config.httpVersion">
-            <a-radio value="HTTP_1_1">1.1</a-radio>
-            <a-radio value="HTTP_2_0">2.0</a-radio>
-          </a-radio-group>
-          <template #extra
-            >{{ t('page.dashboard.editModal.label.httpVersion.description') }}
-          </template>
-        </a-form-item>
-        <a-form-item
-          field="config.verifySsl"
-          default-checked
-          :label="t('page.dashboard.editModal.label.verifySsl')"
-        >
-          <a-switch v-model="form.config.verifySsl" />
-        </a-form-item>
-      </div>
-      <!-- BiglyBT config block -->
-      <div v-else-if="form.config.type === ClientTypeEnum.BiglyBT">
-        <a-form-item
-          field="config.endpoint"
-          :label="t('page.dashboard.editModal.label.endpoint')"
-          :rules="[{ required: true, type: 'url' }]"
-        >
-          <a-input v-model="form.config.endpoint" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.token" label="Token" required>
-          <a-input v-model="form.config.token" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item
-          field="config.httpVersion"
-          :label="t('page.dashboard.editModal.label.httpVersion')"
-        >
-          <a-radio-group v-model="form.config.httpVersion">
-            <a-radio value="HTTP_1_1">1.1</a-radio>
-            <a-radio value="HTTP_2_0">2.0</a-radio>
-          </a-radio-group>
-          <template #extra
-            >{{ t('page.dashboard.editModal.label.httpVersion.description') }}
-          </template>
-        </a-form-item>
-        <a-form-item
-          field="config.verifySsl"
-          default-checked
-          :label="t('page.dashboard.editModal.label.verifySsl')"
-        >
-          <a-switch v-model="form.config.verifySsl" />
-        </a-form-item>
-      </div>
-      <!-- Deluge config block -->
-      <div v-else-if="form.config.type === ClientTypeEnum.Deluge">
-        <a-form-item
-          field="config.endpoint"
-          :label="t('page.dashboard.editModal.label.endpoint')"
-          :rules="[{ required: true, type: 'url' }]"
-        >
-          <a-input v-model="form.config.endpoint" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item
-          field="config.password"
-          :label="t('page.dashboard.editModal.label.password')"
-          required
-        >
-          <a-input v-model="form.config.password" allow-clear></a-input>
-        </a-form-item>
-        <a-form-item field="config.rpcUrl" label="RPC URL" required>
-          <a-input v-model="form.config.rpcUrl" allow-clear placeholder="/json"></a-input>
-        </a-form-item>
-        <a-form-item
-          field="config.incrementBan"
-          default-checked
-          :label="t('page.dashboard.editModal.label.incrementBan')"
-        >
-          <a-switch v-model="form.config.incrementBan" />
-          <template #extra>
-            {{ t('page.dashboard.editModal.label.incrementBan.description') }}</template
-          >
-        </a-form-item>
-        <a-form-item
-          field="config.httpVersion"
-          :label="t('page.dashboard.editModal.label.httpVersion')"
-        >
-          <a-radio-group v-model="form.config.httpVersion">
-            <a-radio value="HTTP_1_1">1.1</a-radio>
-            <a-radio value="HTTP_2_0">2.0</a-radio>
-          </a-radio-group>
-          <template #extra
-            >{{ t('page.dashboard.editModal.label.httpVersion.description') }}
-          </template>
-        </a-form-item>
-        <a-form-item
-          field="config.verifySsl"
-          default-checked
-          :label="t('page.dashboard.editModal.label.verifySsl')"
-        >
-          <a-switch v-model="form.config.verifySsl" />
-        </a-form-item>
-      </div>
+      <component :is="formMap[form.config.type]" v-model="form.config" />
     </a-form>
   </a-modal>
 </template>
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { reactive, ref } from 'vue'
+import { defineAsyncComponent, reactive, ref } from 'vue'
 import { Message, type Form } from '@arco-design/web-vue'
 import { ClientTypeEnum, type downloaderConfig } from '@/api/model/clientStatus'
 import { CreateDownloader, TestDownloaderConfig, UpdateDownloader } from '@/service/downloaders'
+const qbittorrentForm = defineAsyncComponent(() => import('./forms/qbittorrent.vue'))
+const transmissionForm = defineAsyncComponent(() => import('./forms/transmission.vue'))
+const biglybtForm = defineAsyncComponent(() => import('./forms/biglybt.vue'))
+const delugeForm = defineAsyncComponent(() => import('./forms/deluge.vue'))
+
 const { t } = useI18n()
 const showModal = ref(false)
 const newItem = ref(false)
-const useBasicAuth = ref(false)
+
+const formMap = {
+  [ClientTypeEnum.qBittorrent]: qbittorrentForm,
+  [ClientTypeEnum.Transmission]: transmissionForm,
+  [ClientTypeEnum.BiglyBT]: biglybtForm,
+  [ClientTypeEnum.Deluge]: delugeForm
+}
+
 const form = reactive({
   name: '',
   config: { basicAuth: {}, verifySsl: true, httpVersion: 'HTTP_1_1' } as downloaderConfig
@@ -236,13 +68,9 @@ defineExpose({
       form.name = currentConfig.name
       oldName.value = currentConfig.name
       form.config = currentConfig.config
-      if (form.config.type === ClientTypeEnum.qBittorrent) {
-        useBasicAuth.value = form.config.basicAuth.pass !== '' || form.config.basicAuth.user !== ''
-      }
     } else {
       form.name = ''
       form.config = { basicAuth: {}, verifySsl: true, httpVersion: 'HTTP_1_1' } as downloaderConfig
-      useBasicAuth.value = false
     }
     showModal.value = true
   }

--- a/src/views/dashboard/components/forms/biglybt.vue
+++ b/src/views/dashboard/components/forms/biglybt.vue
@@ -1,0 +1,32 @@
+<template>
+  <a-form-item
+    field="config.endpoint"
+    :label="t('page.dashboard.editModal.label.endpoint')"
+    :rules="[{ required: true, type: 'url' }]"
+  >
+    <a-input v-model="config.endpoint" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.token" label="Token" required>
+    <a-input v-model="config.token" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
+    <a-radio-group v-model="config.httpVersion">
+      <a-radio value="HTTP_1_1">1.1</a-radio>
+      <a-radio value="HTTP_2_0">2.0</a-radio>
+    </a-radio-group>
+    <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
+  </a-form-item>
+  <a-form-item
+    field="config.verifySsl"
+    default-checked
+    :label="t('page.dashboard.editModal.label.verifySsl')"
+  >
+    <a-switch v-model="config.verifySsl" />
+  </a-form-item>
+</template>
+<script setup lang="ts">
+import type { biglybtConfig } from '@/api/model/clientStatus'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+const config = defineModel<biglybtConfig>({ required: true })
+</script>

--- a/src/views/dashboard/components/forms/deluge.vue
+++ b/src/views/dashboard/components/forms/deluge.vue
@@ -1,0 +1,47 @@
+<template>
+  <a-form-item
+    field="config.endpoint"
+    :label="t('page.dashboard.editModal.label.endpoint')"
+    :rules="[{ required: true, type: 'url' }]"
+  >
+    <a-input v-model="config.endpoint" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item
+    field="config.password"
+    :label="t('page.dashboard.editModal.label.password')"
+    required
+  >
+    <a-input v-model="config.password" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.rpcUrl" label="RPC URL" required>
+    <a-input v-model="config.rpcUrl" allow-clear placeholder="/json"></a-input>
+  </a-form-item>
+  <a-form-item
+    field="config.incrementBan"
+    default-checked
+    :label="t('page.dashboard.editModal.label.incrementBan')"
+  >
+    <a-switch v-model="config.incrementBan" />
+    <template #extra> {{ t('page.dashboard.editModal.label.incrementBan.description') }}</template>
+  </a-form-item>
+  <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
+    <a-radio-group v-model="config.httpVersion">
+      <a-radio value="HTTP_1_1">1.1</a-radio>
+      <a-radio value="HTTP_2_0">2.0</a-radio>
+    </a-radio-group>
+    <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
+  </a-form-item>
+  <a-form-item
+    field="config.verifySsl"
+    default-checked
+    :label="t('page.dashboard.editModal.label.verifySsl')"
+  >
+    <a-switch v-model="config.verifySsl" />
+  </a-form-item>
+</template>
+<script setup lang="ts">
+import type { delugeConfig } from '@/api/model/clientStatus'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+const config = defineModel<delugeConfig>({ required: true })
+</script>

--- a/src/views/dashboard/components/forms/qbittorrent.vue
+++ b/src/views/dashboard/components/forms/qbittorrent.vue
@@ -1,0 +1,61 @@
+<template>
+  <a-form-item
+    field="config.endpoint"
+    :label="t('page.dashboard.editModal.label.endpoint')"
+    :rules="[{ required: true, type: 'url' }]"
+  >
+    <a-input v-model="config.endpoint" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.username" :label="t('page.dashboard.editModal.label.username')">
+    <a-input v-model="config.username" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.password" :label="t('page.dashboard.editModal.label.password')">
+    <a-input-password v-model="config.password" allow-clear></a-input-password>
+  </a-form-item>
+  <a-form-item>
+    <a-checkbox v-model="useBasicAuth">
+      {{ t('page.dashboard.editModal.label.useBasicAuth') }}</a-checkbox
+    >
+  </a-form-item>
+  <a-form-item v-if="useBasicAuth" :content-flex="false">
+    <a-form-item field="config.basicAuth.user" label="User">
+      <a-input v-model="config.basicAuth.user" />
+    </a-form-item>
+    <a-form-item field="config.basicAuth.pass" label="Pass">
+      <a-input-password v-model="config.basicAuth.pass" />
+    </a-form-item>
+  </a-form-item>
+  <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
+    <a-radio-group v-model="config.httpVersion">
+      <a-radio value="HTTP_1_1">1.1</a-radio>
+      <a-radio value="HTTP_2_0">2.0</a-radio>
+    </a-radio-group>
+    <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
+  </a-form-item>
+  <a-form-item
+    field="config.incrementBan"
+    default-checked
+    :label="t('page.dashboard.editModal.label.incrementBan')"
+  >
+    <a-switch v-model="config.incrementBan" />
+    <template #extra> {{ t('page.dashboard.editModal.label.incrementBan.description') }}</template>
+  </a-form-item>
+  <a-form-item
+    field="config.verifySsl"
+    default-checked
+    :label="t('page.dashboard.editModal.label.verifySsl')"
+  >
+    <a-switch v-model="config.verifySsl" />
+  </a-form-item>
+</template>
+<script setup lang="ts">
+import type { qBittorrentConfig } from '@/api/model/clientStatus'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+const config = defineModel<qBittorrentConfig>({ required: true })
+const useBasicAuth = ref(false)
+if (config.value?.basicAuth.pass || config.value?.basicAuth.pass) {
+  useBasicAuth.value = true
+}
+</script>

--- a/src/views/dashboard/components/forms/transmission.vue
+++ b/src/views/dashboard/components/forms/transmission.vue
@@ -1,0 +1,38 @@
+<template>
+  <a-form-item
+    field="config.endpoint"
+    :label="t('page.dashboard.editModal.label.endpoint')"
+    :rules="[{ required: true, type: 'url' }]"
+  >
+    <a-input v-model="config.endpoint" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.username" :label="t('page.dashboard.editModal.label.username')">
+    <a-input v-model="config.username" allow-clear></a-input>
+  </a-form-item>
+  <a-form-item field="config.password" :label="t('page.dashboard.editModal.label.password')">
+    <a-input-password v-model="config.password" allow-clear></a-input-password>
+  </a-form-item>
+  <a-form-item field="config.rpcUrl" label="RPC URL" required>
+    <a-input v-model="config.rpcUrl" allow-clear placeholder="/transmission/rpc"></a-input>
+  </a-form-item>
+  <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
+    <a-radio-group v-model="config.httpVersion">
+      <a-radio value="HTTP_1_1">1.1</a-radio>
+      <a-radio value="HTTP_2_0">2.0</a-radio>
+    </a-radio-group>
+    <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
+  </a-form-item>
+  <a-form-item
+    field="config.verifySsl"
+    default-checked
+    :label="t('page.dashboard.editModal.label.verifySsl')"
+  >
+    <a-switch v-model="config.verifySsl" />
+  </a-form-item>
+</template>
+<script setup lang="ts">
+import type { transmissionConfig } from '@/api/model/clientStatus'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+const config = defineModel<transmissionConfig>({ required: true })
+</script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Deluge client settings within the downloader modal on the dashboard.
  - Introduced a new radio button for selecting Deluge as a client type.
  - Added specific form fields for Deluge configuration, including endpoint, password, RPC URL, increment ban, HTTP version, and SSL verification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->