### PR TITLE
修复 GeoAPI 并添加两个新字段

### DIFF
--- a/src/api/model/banlist.ts
+++ b/src/api/model/banlist.ts
@@ -12,8 +12,7 @@ export interface BanMetadata {
   peer: Peer
   description: string
   reverseLookup: string
-  geo?: GeoLocation
-  asn?: ASN
+  geo?: IPGeoData
 }
 
 export interface Torrent {
@@ -37,17 +36,145 @@ export interface Address {
   ip: string
 }
 
-export interface GeoLocation {
-  iso: string
-  countryRegion: string
-  city: string
-  latitude: number
-  longitude: number
-  accuracyRadius: number
+/**
+ * ApifoxModel
+ */
+export interface IPGeoData {
+  /**
+   * 自治系统信息
+   */
+  as?: As;
+  /**
+   * 城市/位置信息
+   */
+  city?: City;
+  /**
+   * 国家/地区信息
+   */
+  country?: Country;
+  /**
+   * 网络属性信息（由 GeoCN 提供）
+   */
+  network?: IPGeoDataNetwork;
+  [property: string]: any;
 }
 
-export interface ASN {
-  asn: number
-  asOrganization: string
-  asNetwork: string
+/**
+* 自治系统信息
+*/
+export interface As {
+  /**
+   * 网络地址
+   */
+  ipAddress?: string;
+  /**
+   * 自治系统网络信息
+   */
+  network?: AsNetwork;
+  /**
+   * 自治系统代码
+   */
+  number?: number;
+  /**
+   * 自治系统所属组织
+   */
+  organization?: string;
+  [property: string]: any;
+}
+
+/**
+* 自治系统网络信息
+*/
+export interface AsNetwork {
+  /**
+   * 网络地址信息
+   */
+  ipAddress?: string;
+  /**
+   * 前缀长度
+   */
+  prefixLength?: number;
+  [property: string]: any;
+}
+
+/**
+* 城市/位置信息
+*/
+export interface City {
+  /**
+   * 城市 ISO 代码/唯一识别代码
+   */
+  iso?: number;
+  /**
+   * 位置信息
+   */
+  location?: Location;
+  /**
+   * 城市名称
+   */
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+* 位置信息
+*/
+export interface Location {
+  /**
+   * 精确半径
+   */
+  accuracyRadius?: number;
+  /**
+   * 维度
+   */
+  latitude?: number;
+  /**
+   * 精度
+   */
+  longitude?: number;
+  /**
+   * 时区
+   */
+  timeZone?: string;
+  [property: string]: any;
+}
+
+/**
+* 国家/地区信息
+*/
+export interface Country {
+  /**
+   * ISO代码
+   */
+  iso?: string;
+  /**
+   * 国家/地区名称
+   */
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+* 网络属性信息（由 GeoCN 提供）
+*/
+export interface IPGeoDataNetwork {
+  /**
+   * 服务提供商信息
+   */
+  isp?: string;
+  /**
+   * 网络类型，常见值如下，这些数据使用中文在 MMDB 中被硬编码，非后端翻译：
+   * 宽带
+   * 基站
+   * 政企专线
+   * 业务平台
+   * 骨干网
+   * IP专网
+   * 网吧
+   * 物联网
+   * 数据中心
+   * （可能增加）
+   */
+  netType?: string;
+  [property: string]: any;
 }

--- a/src/api/model/downloader.ts
+++ b/src/api/model/downloader.ts
@@ -136,7 +136,7 @@ interface Peer {
   /**
    * BitTorrent BEP 标志，https://github.com/PBH-BTN/quick-references/blob/main/utp_flags.md
    */
-  flags: string
+  flags: PeerFlags
   /**
    * BitTorrent BEP PeerID
    */
@@ -153,6 +153,137 @@ interface Peer {
    * 上传速度（单位由下载器决定），单位通常为bytes/s
    */
   uploadSpeed: number
+}
+
+/**
+ * Peer Flags
+ */
+interface PeerFlags{
+  /**
+   * **we** have choked this peer.
+   */
+  choked: boolean;
+  /**
+   * The connection is in a half-open state (i.e. it is being connected).
+   */
+  connecting: boolean;
+  /**
+   * This means the last time this peer picket a piece, it could not pick as many as it wanted
+   * because there were not enough free ones. i.e. all pieces this peer has were already
+   * requested from other peers.
+   */
+  endGameMode: boolean;
+  /**
+   * The peer was received from the kademlia DHT.
+   */
+  fromDHT: boolean;
+  /**
+   * we received an incoming connection from this peer
+   */
+  fromIncoming: boolean;
+  /**
+   * The peer was received from the local service discovery (The peer is on the local network).
+   */
+  fromLSD: boolean;
+  /**
+   * The peer was received from the peer exchange extension.
+   */
+  fromPEX: boolean;
+  /**
+   * The peer was added from the fast resume data.
+   */
+  fromResumeData: boolean;
+  /**
+   * The peer was received from the tracker.
+   */
+  fromTracker: boolean;
+  /**
+   * The connection is opened, and waiting for the handshake. Until the handshake is done, the
+   * peer cannot be identified.
+   */
+  handshake: boolean;
+  /**
+   * This flag is set if the peer was in holepunch mode when the connection succeeded. This
+   * typically only happens if both peers are behind a NAT and the peers connect via the NAT
+   * holepunch mechanism.
+   */
+  holePunched: boolean;
+  /**
+   * indicates that this socket is running on top of the I2P transport.
+   */
+  i2pSocket: boolean;
+  /**
+   * **we** are interested in pieces from this peer.
+   */
+  interesting: boolean;
+  /**
+   * deprecated synonym for outgoing_connection
+   */
+  localConnection: boolean;
+  /**
+   * 标准 libTorrent 标志，不管下载器原始 Flags 如何，PBH 总是将其转换为 LT 的 Flags
+   */
+  ltStdString: string;
+  /**
+   * The peer has participated in a piece that failed the hash check, and is now "on parole",
+   * which means we're only requesting whole pieces from this peer until it either fails that
+   * piece or proves that it doesn't send bad data.
+   */
+  onParole: boolean;
+  /**
+   * This peer is subject to an optimistic unchoke. It has been unchoked for a while to see if
+   * it might unchoke us in return an earn an upload/unchoke slot. If it doesn't within some
+   * period of time, it will be choked and another peer will be optimistically unchoked.
+   */
+  optimisticUnchoke: boolean;
+  /**
+   * The connection was initiated by us, the peer has a listen port open, and that port is the
+   * same as in the address of this peer. If this flag is not set, this peer connection was
+   * opened by this peer connecting to us.
+   */
+  outgoingConnection: boolean;
+  /**
+   * the handshake of this connection was obfuscated with a Diffie-Hellman exchange
+   */
+  plainTextEncrypted: boolean;
+  /**
+   * this connection is obfuscated with RC4
+   */
+  rc4Encrypted: boolean;
+  /**
+   * the peer has choked **us**.
+   */
+  remoteChoked: boolean;
+  /**
+   * the peer is interested in **us**
+   */
+  remoteInterested: boolean;
+  /**
+   * This peer is a seed (it has all the pieces).
+   */
+  seed: boolean;
+  /**
+   * This peer has recently failed to send a block within the request timeout from when the
+   * request was sent. We're currently picking one block at a time from this peer.
+   */
+  snubbed: boolean;
+  /**
+   * indicates that this socket is running on top of an SSL (TLS) channel
+   */
+  sslSocket: boolean;
+  /**
+   * means that this peer supports the extension protocol
+   */
+  supportsExtensions: boolean;
+  /**
+   * This peer has either explicitly (with an extension) or implicitly (by becoming a seed)
+   * told us that it will not downloading anything more, regardless of which pieces we have.
+   */
+  uploadOnly: boolean;
+  /**
+   * indicates that this socket is a uTP socket
+   */
+  utpSocket: boolean;
 }
 
 /**

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -57,30 +57,30 @@
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="4"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.iso" />
-      {{ `${item.banMetadata.geo?.countryRegion} ${item.banMetadata.geo?.city ?? ''}` }}
+      <CountryFlag :iso="item.banMetadata.geo?.country.iso" />
+      {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
       <a-link
-        :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.longitude},${item.banMetadata.geo?.latitude}`"
+        :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
         :hoverable="false"
       >
         <icon-location />
       </a-link>
     </a-descriptions-item>
     <a-descriptions-item
-      v-if="item.banMetadata.asn"
+      v-if="item.banMetadata.geo?.as"
       :label="t('page.banlist.banlist.listItem.asn')"
       :span="4"
     >
       <a-space>
-        <a-typography-text> {{ item.banMetadata.asn?.asOrganization }}</a-typography-text>
-        <a-tag :color="getColor(item.banMetadata.asn?.asn.toString())">{{
-          item.banMetadata.asn?.asn
+        <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
+        <a-tag :color="getColor(item.banMetadata.geo?.as?.number.toString())">{{
+          item.banMetadata.geo?.as?.number
         }}</a-tag>
         <a-tooltip
-          :content="t('page.banlist.banlist.listItem.asn.subnet') + item.banMetadata.asn?.asNetwork"
+          :content="t('page.banlist.banlist.listItem.asn.subnet') + item.banMetadata.geo?.as?.network?.ipAddress"
         >
           <a-link
-            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.asn?.asn}`"
+            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.asn?.number}`"
             :hoverable="false"
           >
             <icon-info-circle />
@@ -94,6 +94,21 @@
       :span="4"
     >
       {{ item.banMetadata.reverseLookup }}
+    </a-descriptions-item>
+    
+    <a-descriptions-item
+      v-if="item.banMetadata.geo?.network?.isp"
+      :label="t('page.banlist.banlist.listItem.network.isp')"
+      :span="12"
+    >
+    {{ item.banMetadata.geo?.network?.isp }}
+    </a-descriptions-item>
+    <a-descriptions-item
+      v-if="item.banMetadata.geo?.network?.netType"
+      :label="t('page.banlist.banlist.listItem.network.netType')"
+      :span="12"
+    >
+    {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>
   </a-descriptions>
 </template>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -99,14 +99,14 @@
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.isp"
       :label="t('page.banlist.banlist.listItem.network.isp')"
-      :span="12"
+      :span="6"
     >
     {{ item.banMetadata.geo?.network?.isp }}
     </a-descriptions-item>
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.netType"
       :label="t('page.banlist.banlist.listItem.network.netType')"
-      :span="12"
+      :span="6"
     >
     {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -57,7 +57,7 @@
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="4"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.country.iso" />
+      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? '?'" />
       {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
       <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
@@ -73,7 +73,7 @@
     >
       <a-space>
         <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
-        <a-tag :color="getColor(item.banMetadata.geo?.as?.number.toString())">{{
+        <a-tag :color="getColor((item.banMetadata.geo?.as?.number ?? 0).toString())">{{
           item.banMetadata.geo?.as?.number
         }}</a-tag>
         <a-tooltip

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -12,5 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': 'ASN Subnet: ',
   'page.banlist.banlist.listItem.empty': 'Empty',
+  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.netType': 'Net Type: ',
   'page.banlist.banlist.bottomReached': 'No more data!'
 }

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -12,7 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': 'ASN Subnet: ',
   'page.banlist.banlist.listItem.empty': 'Empty',
-  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
-  'page.banlist.banlist.listItem.network.netType': 'Net Type: ',
+  'page.banlist.banlist.listItem.network.isp': 'ISP',
+  'page.banlist.banlist.listItem.network.net': 'Net',
   'page.banlist.banlist.bottomReached': 'No more data!'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -12,7 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': '子网：',
   'page.banlist.banlist.listItem.empty': '空',
-  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.isp': 'ISP',
   'page.banlist.banlist.listItem.network.netType': '网络类型: ',
   'page.banlist.banlist.bottomReached': '已经到底啦！'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -12,5 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': '子网：',
   'page.banlist.banlist.listItem.empty': '空',
+  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.netType': '网络类型: ',
   'page.banlist.banlist.bottomReached': '已经到底啦！'
 }


### PR DESCRIPTION
## 新功能

两个新字段，分别是 ISP 和 网络类型，但我不能把这两个新字段移动到单独的一行。

![image](https://github.com/PBH-BTN/pbh-fe/assets/30802565/33045f7f-8955-4413-80c0-3b0b4db1b7dc)

## 错误修复

修复了标志位因 API 更改显示为 `[object Object]` 的问题，但似乎 tooltip 的换行有些问题。

![image](https://github.com/PBH-BTN/pbh-fe/assets/30802565/6b2d5061-e581-443a-8c32-efd4856ccd18)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed ISP and network type information display in the ban list.

- **Enhancements**
  - Improved geographic and ASN information display in the ban list items for enhanced clarity and detail.

- **Bug Fixes**
  - Corrected mappings for country and city names to ensure accurate display of location information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->