### PR TITLE
Draft: V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbh-fe",
-  "version": "1.7.3",
+  "version": "2.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/api/model/banlist.ts
+++ b/src/api/model/banlist.ts
@@ -12,8 +12,7 @@ export interface BanMetadata {
   peer: Peer
   description: string
   reverseLookup: string
-  geo?: GeoLocation
-  asn?: ASN
+  geo?: IPGeoData
 }
 
 export interface Torrent {
@@ -37,17 +36,145 @@ export interface Address {
   ip: string
 }
 
-export interface GeoLocation {
-  iso: string
-  countryRegion: string
-  city: string
-  latitude: number
-  longitude: number
-  accuracyRadius: number
+/**
+ * ApifoxModel
+ */
+export interface IPGeoData {
+  /**
+   * 自治系统信息
+   */
+  as?: As;
+  /**
+   * 城市/位置信息
+   */
+  city?: City;
+  /**
+   * 国家/地区信息
+   */
+  country?: Country;
+  /**
+   * 网络属性信息（由 GeoCN 提供）
+   */
+  network?: IPGeoDataNetwork;
+  [property: string]: any;
 }
 
-export interface ASN {
-  asn: number
-  asOrganization: string
-  asNetwork: string
+/**
+* 自治系统信息
+*/
+export interface As {
+  /**
+   * 网络地址
+   */
+  ipAddress?: string;
+  /**
+   * 自治系统网络信息
+   */
+  network?: AsNetwork;
+  /**
+   * 自治系统代码
+   */
+  number?: number;
+  /**
+   * 自治系统所属组织
+   */
+  organization?: string;
+  [property: string]: any;
+}
+
+/**
+* 自治系统网络信息
+*/
+export interface AsNetwork {
+  /**
+   * 网络地址信息
+   */
+  ipAddress?: string;
+  /**
+   * 前缀长度
+   */
+  prefixLength?: number;
+  [property: string]: any;
+}
+
+/**
+* 城市/位置信息
+*/
+export interface City {
+  /**
+   * 城市 ISO 代码/唯一识别代码
+   */
+  iso?: number;
+  /**
+   * 位置信息
+   */
+  location?: Location;
+  /**
+   * 城市名称
+   */
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+* 位置信息
+*/
+export interface Location {
+  /**
+   * 精确半径
+   */
+  accuracyRadius?: number;
+  /**
+   * 维度
+   */
+  latitude?: number;
+  /**
+   * 精度
+   */
+  longitude?: number;
+  /**
+   * 时区
+   */
+  timeZone?: string;
+  [property: string]: any;
+}
+
+/**
+* 国家/地区信息
+*/
+export interface Country {
+  /**
+   * ISO代码
+   */
+  iso?: string;
+  /**
+   * 国家/地区名称
+   */
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+* 网络属性信息（由 GeoCN 提供）
+*/
+export interface IPGeoDataNetwork {
+  /**
+   * 服务提供商信息
+   */
+  isp?: string;
+  /**
+   * 网络类型，常见值如下，这些数据使用中文在 MMDB 中被硬编码，非后端翻译：
+   * 宽带
+   * 基站
+   * 政企专线
+   * 业务平台
+   * 骨干网
+   * IP专网
+   * 网吧
+   * 物联网
+   * 数据中心
+   * （可能增加）
+   */
+  netType?: string;
+  [property: string]: any;
 }

--- a/src/api/model/banlist.ts
+++ b/src/api/model/banlist.ts
@@ -10,6 +10,7 @@ export interface BanMetadata {
   unbanAt: number
   torrent: Torrent
   peer: Peer
+  rule: string
   description: string
   reverseLookup: string
   geo?: IPGeoData

--- a/src/api/model/banlist.ts
+++ b/src/api/model/banlist.ts
@@ -36,132 +36,123 @@ export interface Address {
   ip: string
 }
 
-/**
- * ApifoxModel
- */
 export interface IPGeoData {
   /**
    * 自治系统信息
    */
-  as?: As;
+  as?: As
   /**
    * 城市/位置信息
    */
-  city?: City;
+  city?: City
   /**
    * 国家/地区信息
    */
-  country?: Country;
+  country?: Country
   /**
    * 网络属性信息（由 GeoCN 提供）
    */
-  network?: IPGeoDataNetwork;
-  [property: string]: any;
+  network?: IPGeoDataNetwork
 }
 
 /**
-* 自治系统信息
-*/
+ * 自治系统信息
+ */
 export interface As {
   /**
    * 网络地址
    */
-  ipAddress?: string;
+  ipAddress?: string
   /**
    * 自治系统网络信息
    */
-  network?: AsNetwork;
+  network?: AsNetwork
   /**
    * 自治系统代码
    */
-  number?: number;
+  number?: number
   /**
    * 自治系统所属组织
    */
-  organization?: string;
-  [property: string]: any;
+  organization?: string
 }
 
 /**
-* 自治系统网络信息
-*/
+ * 自治系统网络信息
+ */
 export interface AsNetwork {
   /**
    * 网络地址信息
    */
-  ipAddress?: string;
+  ipAddress?: string
   /**
    * 前缀长度
    */
-  prefixLength?: number;
-  [property: string]: any;
+  prefixLength?: number
 }
 
 /**
-* 城市/位置信息
-*/
+ * 城市/位置信息
+ */
 export interface City {
   /**
    * 城市 ISO 代码/唯一识别代码
    */
-  iso?: number;
+  iso?: number
   /**
    * 位置信息
    */
-  location?: Location;
+  location?: Location
   /**
    * 城市名称
    */
-  name?: string;
-  [property: string]: any;
+  name?: string
 }
 
 /**
-* 位置信息
-*/
+ * 位置信息
+ */
 export interface Location {
   /**
    * 精确半径
    */
-  accuracyRadius?: number;
+  accuracyRadius?: number
   /**
    * 维度
    */
-  latitude?: number;
+  latitude?: number
   /**
    * 精度
    */
-  longitude?: number;
+  longitude?: number
   /**
    * 时区
    */
-  timeZone?: string;
-  [property: string]: any;
+  timeZone?: string
 }
 
 /**
-* 国家/地区信息
-*/
+ * 国家/地区信息
+ */
 export interface Country {
   /**
    * ISO代码
    */
-  iso?: string;
+  iso?: string
   /**
    * 国家/地区名称
    */
-  name?: string;
-  [property: string]: any;
+  name?: string
 }
 
 /**
-* 网络属性信息（由 GeoCN 提供）
-*/
+ * 网络属性信息（由 GeoCN 提供）
+ */
 export interface IPGeoDataNetwork {
   /**
    * 服务提供商信息
    */
-  isp?: string;
+  isp?: string
   /**
    * 网络类型，常见值如下，这些数据使用中文在 MMDB 中被硬编码，非后端翻译：
    * 宽带
@@ -175,6 +166,5 @@ export interface IPGeoDataNetwork {
    * 数据中心
    * （可能增加）
    */
-  netType?: string;
-  [property: string]: any;
+  netType?: string
 }

--- a/src/api/model/banlist.ts
+++ b/src/api/model/banlist.ts
@@ -169,3 +169,7 @@ export interface IPGeoDataNetwork {
    */
   netType?: string
 }
+
+export interface UnbanCallback {
+  count?: number
+}

--- a/src/api/model/downloader.ts
+++ b/src/api/model/downloader.ts
@@ -2,13 +2,15 @@ export interface ClientStatus {
   activePeers: number
   activeTorrents: number
   lastStatus: ClientStatusEnum
+  lastStatusMessage: string
   config: downloaderConfig
 }
 
 export enum ClientStatusEnum {
   HEALTHY = 'HEALTHY',
   ERROR = 'ERROR',
-  UNKNOWN = 'UNKNOWN'
+  UNKNOWN = 'UNKNOWN',
+  NEED_TAKE_ACTION = 'NEED_TAKE_ACTION'
 }
 
 export enum ClientTypeEnum {

--- a/src/api/model/downloader.ts
+++ b/src/api/model/downloader.ts
@@ -136,7 +136,7 @@ interface Peer {
   /**
    * BitTorrent BEP 标志，https://github.com/PBH-BTN/quick-references/blob/main/utp_flags.md
    */
-  flags: string
+  flags: PeerFlags
   /**
    * BitTorrent BEP PeerID
    */
@@ -153,6 +153,137 @@ interface Peer {
    * 上传速度（单位由下载器决定），单位通常为bytes/s
    */
   uploadSpeed: number
+}
+
+/**
+ * Peer Flags
+ */
+interface PeerFlags{
+  /**
+   * **we** have choked this peer.
+   */
+  choked: boolean;
+  /**
+   * The connection is in a half-open state (i.e. it is being connected).
+   */
+  connecting: boolean;
+  /**
+   * This means the last time this peer picket a piece, it could not pick as many as it wanted
+   * because there were not enough free ones. i.e. all pieces this peer has were already
+   * requested from other peers.
+   */
+  endGameMode: boolean;
+  /**
+   * The peer was received from the kademlia DHT.
+   */
+  fromDHT: boolean;
+  /**
+   * we received an incoming connection from this peer
+   */
+  fromIncoming: boolean;
+  /**
+   * The peer was received from the local service discovery (The peer is on the local network).
+   */
+  fromLSD: boolean;
+  /**
+   * The peer was received from the peer exchange extension.
+   */
+  fromPEX: boolean;
+  /**
+   * The peer was added from the fast resume data.
+   */
+  fromResumeData: boolean;
+  /**
+   * The peer was received from the tracker.
+   */
+  fromTracker: boolean;
+  /**
+   * The connection is opened, and waiting for the handshake. Until the handshake is done, the
+   * peer cannot be identified.
+   */
+  handshake: boolean;
+  /**
+   * This flag is set if the peer was in holepunch mode when the connection succeeded. This
+   * typically only happens if both peers are behind a NAT and the peers connect via the NAT
+   * holepunch mechanism.
+   */
+  holePunched: boolean;
+  /**
+   * indicates that this socket is running on top of the I2P transport.
+   */
+  i2pSocket: boolean;
+  /**
+   * **we** are interested in pieces from this peer.
+   */
+  interesting: boolean;
+  /**
+   * deprecated synonym for outgoing_connection
+   */
+  localConnection: boolean;
+  /**
+   * 标准 libTorrent 标志，不管下载器原始 Flags 如何，PBH 总是将其转换为 LT 的 Flags
+   */
+  ltStdString: string;
+  /**
+   * The peer has participated in a piece that failed the hash check, and is now "on parole",
+   * which means we're only requesting whole pieces from this peer until it either fails that
+   * piece or proves that it doesn't send bad data.
+   */
+  onParole: boolean;
+  /**
+   * This peer is subject to an optimistic unchoke. It has been unchoked for a while to see if
+   * it might unchoke us in return an earn an upload/unchoke slot. If it doesn't within some
+   * period of time, it will be choked and another peer will be optimistically unchoked.
+   */
+  optimisticUnchoke: boolean;
+  /**
+   * The connection was initiated by us, the peer has a listen port open, and that port is the
+   * same as in the address of this peer. If this flag is not set, this peer connection was
+   * opened by this peer connecting to us.
+   */
+  outgoingConnection: boolean;
+  /**
+   * the handshake of this connection was obfuscated with a Diffie-Hellman exchange
+   */
+  plainTextEncrypted: boolean;
+  /**
+   * this connection is obfuscated with RC4
+   */
+  rc4Encrypted: boolean;
+  /**
+   * the peer has choked **us**.
+   */
+  remoteChoked: boolean;
+  /**
+   * the peer is interested in **us**
+   */
+  remoteInterested: boolean;
+  /**
+   * This peer is a seed (it has all the pieces).
+   */
+  seed: boolean;
+  /**
+   * This peer has recently failed to send a block within the request timeout from when the
+   * request was sent. We're currently picking one block at a time from this peer.
+   */
+  snubbed: boolean;
+  /**
+   * indicates that this socket is running on top of an SSL (TLS) channel
+   */
+  sslSocket: boolean;
+  /**
+   * means that this peer supports the extension protocol
+   */
+  supportsExtensions: boolean;
+  /**
+   * This peer has either explicitly (with an extension) or implicitly (by becoming a seed)
+   * told us that it will not downloading anything more, regardless of which pieces we have.
+   */
+  uploadOnly: boolean;
+  /**
+   * indicates that this socket is a uTP socket
+   */
+  utpSocket: boolean;
 }
 
 /**

--- a/src/api/model/downloader.ts
+++ b/src/api/model/downloader.ts
@@ -164,64 +164,64 @@ interface PeerFlags{
   /**
    * **we** have choked this peer.
    */
-  choked: boolean;
+  choked?: boolean;
   /**
    * The connection is in a half-open state (i.e. it is being connected).
    */
-  connecting: boolean;
+  connecting?: boolean;
   /**
    * This means the last time this peer picket a piece, it could not pick as many as it wanted
    * because there were not enough free ones. i.e. all pieces this peer has were already
    * requested from other peers.
    */
-  endGameMode: boolean;
+  endGameMode?: boolean;
   /**
    * The peer was received from the kademlia DHT.
    */
-  fromDHT: boolean;
+  fromDHT?: boolean;
   /**
    * we received an incoming connection from this peer
    */
-  fromIncoming: boolean;
+  fromIncoming?: boolean;
   /**
    * The peer was received from the local service discovery (The peer is on the local network).
    */
-  fromLSD: boolean;
+  fromLSD?: boolean;
   /**
    * The peer was received from the peer exchange extension.
    */
-  fromPEX: boolean;
+  fromPEX?: boolean;
   /**
    * The peer was added from the fast resume data.
    */
-  fromResumeData: boolean;
+  fromResumeData?: boolean;
   /**
    * The peer was received from the tracker.
    */
-  fromTracker: boolean;
+  fromTracker?: boolean;
   /**
    * The connection is opened, and waiting for the handshake. Until the handshake is done, the
    * peer cannot be identified.
    */
-  handshake: boolean;
+  handshake?: boolean;
   /**
    * This flag is set if the peer was in holepunch mode when the connection succeeded. This
    * typically only happens if both peers are behind a NAT and the peers connect via the NAT
    * holepunch mechanism.
    */
-  holePunched: boolean;
+  holePunched?: boolean;
   /**
    * indicates that this socket is running on top of the I2P transport.
    */
-  i2pSocket: boolean;
+  i2pSocket?: boolean;
   /**
    * **we** are interested in pieces from this peer.
    */
-  interesting: boolean;
+  interesting?: boolean;
   /**
    * deprecated synonym for outgoing_connection
    */
-  localConnection: boolean;
+  localConnection?: boolean;
   /**
    * 标准 libTorrent 标志，不管下载器原始 Flags 如何，PBH 总是将其转换为 LT 的 Flags
    */
@@ -231,61 +231,61 @@ interface PeerFlags{
    * which means we're only requesting whole pieces from this peer until it either fails that
    * piece or proves that it doesn't send bad data.
    */
-  onParole: boolean;
+  onParole?: boolean;
   /**
    * This peer is subject to an optimistic unchoke. It has been unchoked for a while to see if
    * it might unchoke us in return an earn an upload/unchoke slot. If it doesn't within some
    * period of time, it will be choked and another peer will be optimistically unchoked.
    */
-  optimisticUnchoke: boolean;
+  optimisticUnchoke?: boolean;
   /**
    * The connection was initiated by us, the peer has a listen port open, and that port is the
    * same as in the address of this peer. If this flag is not set, this peer connection was
    * opened by this peer connecting to us.
    */
-  outgoingConnection: boolean;
+  outgoingConnection?: boolean;
   /**
    * the handshake of this connection was obfuscated with a Diffie-Hellman exchange
    */
-  plainTextEncrypted: boolean;
+  plainTextEncrypted?: boolean;
   /**
    * this connection is obfuscated with RC4
    */
-  rc4Encrypted: boolean;
+  rc4Encrypted?: boolean;
   /**
    * the peer has choked **us**.
    */
-  remoteChoked: boolean;
+  remoteChoked?: boolean;
   /**
    * the peer is interested in **us**
    */
-  remoteInterested: boolean;
+  remoteInterested?: boolean;
   /**
    * This peer is a seed (it has all the pieces).
    */
-  seed: boolean;
+  seed?: boolean;
   /**
    * This peer has recently failed to send a block within the request timeout from when the
    * request was sent. We're currently picking one block at a time from this peer.
    */
-  snubbed: boolean;
+  snubbed?: boolean;
   /**
    * indicates that this socket is running on top of an SSL (TLS) channel
    */
-  sslSocket: boolean;
+  sslSocket?: boolean;
   /**
    * means that this peer supports the extension protocol
    */
-  supportsExtensions: boolean;
+  supportsExtensions?: boolean;
   /**
    * This peer has either explicitly (with an extension) or implicitly (by becoming a seed)
    * told us that it will not downloading anything more, regardless of which pieces we have.
    */
-  uploadOnly: boolean;
+  uploadOnly?: boolean;
   /**
    * indicates that this socket is a uTP socket
    */
-  utpSocket: boolean;
+  utpSocket?: boolean;
 }
 
 /**

--- a/src/service/banList.ts
+++ b/src/service/banList.ts
@@ -1,4 +1,4 @@
-import type { BanList } from '@/api/model/banlist'
+import { type BanList, type UnbanCallback } from '@/api/model/banlist'
 import { useEndpointStore } from '@/stores/endpoint'
 import urlJoin from 'url-join'
 import { getCommonHeader } from './utils'
@@ -15,4 +15,16 @@ export async function getBanList(limit: number, lastBanTime?: number): Promise<B
   return fetch(url, {
     headers: getCommonHeader()
   }).then((res) => { endpointStore.assertResponseLogin(res); return res.json() })
+}
+
+export async function unbanIP(arr: Array<string>): Promise<UnbanCallback> {
+  const endpointStore = useEndpointStore()
+  await endpointStore.serverAvailable
+  console.trace()
+  const url = new URL(urlJoin(endpointStore.endpoint, 'api/bans'), location.href)
+  return fetch(url, {
+    headers: getCommonHeader(),
+    method: 'DELETE',
+    body: JSON.stringify( arr )
+  }).then((res)=>{ return res.json() })
 }

--- a/src/service/banList.ts
+++ b/src/service/banList.ts
@@ -20,7 +20,6 @@ export async function getBanList(limit: number, lastBanTime?: number): Promise<B
 export async function unbanIP(arr: Array<string>): Promise<UnbanCallback> {
   const endpointStore = useEndpointStore()
   await endpointStore.serverAvailable
-  console.trace()
   const url = new URL(urlJoin(endpointStore.endpoint, 'api/bans'), location.href)
   return fetch(url, {
     headers: getCommonHeader(),

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -29,6 +29,7 @@ export default function useLocale() {
   if (store.localeStore !== '' && i18.availableLocales.includes(store.localeStore)) {
     changeLocale(store.localeStore)
   }
+  document.querySelector('html')?.setAttribute('lang', i18.locale.value)
 
   return {
     changeLocale

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,5 @@
 export function formatFileSize(bytes: number, decimals = 2) {
-  if (bytes === -1) return '?' // 在没有完成元数据拉取之前，部分下载器会返回 -1 值
+  if (bytes === -1) return 'N/A' // 在没有完成元数据拉取之前，部分下载器会返回 -1 值
   if (bytes === 0) return '0 Bytes'
 
   const k = 1024

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,4 +1,5 @@
 export function formatFileSize(bytes: number, decimals = 2) {
+  if (bytes === -1) return '?' // 在没有完成元数据拉取之前，部分下载器会返回 -1 值
   if (bytes === 0) return '0 Bytes'
 
   const k = 1024

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -49,11 +49,11 @@
         `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ??
         t('page.banlist.banlist.listItem.empty')}`
       }}
-      <a-link
+      <!-- <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
         :hoverable="false">
         <icon-location />
-      </a-link>
+      </a-link> -->
     </a-descriptions-item>
     <a-descriptions-item v-if="item.banMetadata.geo?.as" :label="t('page.banlist.banlist.listItem.asn')" :span="6">
       <a-space>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -57,30 +57,30 @@
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="4"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.iso" />
-      {{ `${item.banMetadata.geo?.countryRegion} ${item.banMetadata.geo?.city ?? ''}` }}
+      <CountryFlag :iso="item.banMetadata.geo?.country.iso" />
+      {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
       <a-link
-        :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.longitude},${item.banMetadata.geo?.latitude}`"
+        :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
         :hoverable="false"
       >
         <icon-location />
       </a-link>
     </a-descriptions-item>
     <a-descriptions-item
-      v-if="item.banMetadata.asn"
+      v-if="item.banMetadata.geo?.as"
       :label="t('page.banlist.banlist.listItem.asn')"
       :span="4"
     >
       <a-space>
-        <a-typography-text> {{ item.banMetadata.asn?.asOrganization }}</a-typography-text>
-        <a-tag :color="getColor(item.banMetadata.asn?.asn.toString())">{{
-          item.banMetadata.asn?.asn
+        <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
+        <a-tag :color="getColor(item.banMetadata.geo?.as?.number.toString())">{{
+          item.banMetadata.geo?.as?.number
         }}</a-tag>
         <a-tooltip
-          :content="t('page.banlist.banlist.listItem.asn.subnet') + item.banMetadata.asn?.asNetwork"
+          :content="t('page.banlist.banlist.listItem.asn.subnet') + item.banMetadata.geo?.as?.network?.ipAddress"
         >
           <a-link
-            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.asn?.asn}`"
+            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.asn?.number}`"
             :hoverable="false"
           >
             <icon-info-circle />
@@ -94,6 +94,21 @@
       :span="4"
     >
       {{ item.banMetadata.reverseLookup }}
+    </a-descriptions-item>
+    
+    <a-descriptions-item
+      v-if="item.banMetadata.geo?.network?.isp"
+      :label="t('page.banlist.banlist.listItem.network.isp')"
+      :span="12"
+    >
+    {{ item.banMetadata.geo?.network?.isp }}
+    </a-descriptions-item>
+    <a-descriptions-item
+      v-if="item.banMetadata.geo?.network?.netType"
+      :label="t('page.banlist.banlist.listItem.network.netType')"
+      :span="12"
+    >
+    {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>
   </a-descriptions>
 </template>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -99,14 +99,14 @@
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.isp"
       :label="t('page.banlist.banlist.listItem.network.isp')"
-      :span="12"
+      :span="6"
     >
     {{ item.banMetadata.geo?.network?.isp }}
     </a-descriptions-item>
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.netType"
       :label="t('page.banlist.banlist.listItem.network.netType')"
-      :span="12"
+      :span="6"
     >
     {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -1,21 +1,15 @@
 <template>
-  <a-descriptions
-    :column="{ xs: 3, md: 6, xl: 12 }"
-    size="medium"
-    :layout="(['inline-vertical', 'horizontal'] as const)[descriptionLayout]"
-  >
+  <a-descriptions :column="{ xs: 3, md: 6, xl: 12 }" size="medium"
+    :layout="(['inline-vertical', 'horizontal'] as const)[descriptionLayout]">
     <template #title>
       <a-space wrap>
         <a-typography-text bold copyable>
           {{ item.banMetadata.peer.address.ip }}:{{ item.banMetadata.peer.address.port }}
         </a-typography-text>
-        <a-tooltip
-          :content="
-            item.banMetadata.peer.id
-              ? item.banMetadata.peer.id
-              : t('page.banlist.banlist.listItem.empty')
-          "
-        >
+        <a-tooltip :content="item.banMetadata.peer.id
+          ? item.banMetadata.peer.id
+          : t('page.banlist.banlist.listItem.empty')
+          ">
           <a-typography-text code>
             {{
               item.banMetadata.peer.clientName
@@ -24,6 +18,13 @@
             }}
           </a-typography-text>
         </a-tooltip>
+        <AsyncMethod once :async-fn="() => handleUnban(item.banMetadata.peer.address.ip)" v-slot="{ run, loading }">
+          <a-tooltip :content="t('page.banlist.banlist.listItem.unban')">
+            <a-button shape="circle" :disabled="loading" @click.prevent="run">
+              <icon-delete />
+            </a-button>
+          </a-tooltip>
+        </AsyncMethod>
       </a-space>
     </template>
     <a-descriptions-item :label="t('page.banlist.banlist.listItem.banTime')" :span="6">
@@ -40,64 +41,44 @@
       - {{ (item.banMetadata.peer.progress * 100).toFixed(2) }}%
     </a-descriptions-item>
 
-    <a-descriptions-item
-      v-if="item.banMetadata.geo"
-      :label="t('page.banlist.banlist.listItem.geo')"
-      :span="6"
-    >
-      <CountryFlag
-        :iso="item.banMetadata.geo?.country?.iso ?? t('page.banlist.banlist.listItem.empty')"
-      />
+    <a-descriptions-item v-if="item.banMetadata.geo" :label="t('page.banlist.banlist.listItem.geo')" :span="6">
+      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? t('page.banlist.banlist.listItem.empty')" />
       {{
-        `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? t('page.banlist.banlist.listItem.empty')}`
+        `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ??
+        t('page.banlist.banlist.listItem.empty')}`
       }}
       <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
-        :hoverable="false"
-      >
+        :hoverable="false">
         <icon-location />
       </a-link>
     </a-descriptions-item>
-    <a-descriptions-item
-      v-if="item.banMetadata.geo?.as"
-      :label="t('page.banlist.banlist.listItem.asn')"
-      :span="6"
-    >
+    <a-descriptions-item v-if="item.banMetadata.geo?.as" :label="t('page.banlist.banlist.listItem.asn')" :span="6">
       <a-space>
         <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
         <a-tag :color="getColor((item.banMetadata.geo?.as?.number ?? 0).toString())">{{
           item.banMetadata.geo?.as?.number
         }}</a-tag>
-        <a-tooltip
-          :content="
-            t('page.banlist.banlist.listItem.asn.subnet') +
-            item.banMetadata.geo?.as?.network?.ipAddress
-          "
-        >
-          <a-link
-            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.as?.number}`"
-            :hoverable="false"
-          >
+        <a-tooltip :content="t('page.banlist.banlist.listItem.asn.subnet') +
+          item.banMetadata.geo?.as?.network?.ipAddress
+          ">
+          <a-link :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.as?.number}`"
+            :hoverable="false">
             <icon-info-circle />
           </a-link>
         </a-tooltip>
       </a-space>
     </a-descriptions-item>
-    <a-descriptions-item v-if="item.banMetadata.reverseLookup != 'N/A'" :label="t('page.banlist.banlist.listItem.reserveDNSLookup')" :span="6">
+    <a-descriptions-item v-if="item.banMetadata.reverseLookup != 'N/A'"
+      :label="t('page.banlist.banlist.listItem.reserveDNSLookup')" :span="6">
       {{ item.banMetadata.reverseLookup }}
     </a-descriptions-item>
-    <a-descriptions-item
-      v-if="item.banMetadata.geo?.network?.isp"
-      :label="t('page.banlist.banlist.listItem.network.isp')"
-      :span="6"
-    >
+    <a-descriptions-item v-if="item.banMetadata.geo?.network?.isp"
+      :label="t('page.banlist.banlist.listItem.network.isp')" :span="6">
       {{ item.banMetadata.geo?.network?.isp }}
     </a-descriptions-item>
-    <a-descriptions-item
-      v-if="item.banMetadata.geo?.network?.netType"
-      :label="t('page.banlist.banlist.listItem.network.netType')"
-      :span="6"
-    >
+    <a-descriptions-item v-if="item.banMetadata.geo?.network?.netType"
+      :label="t('page.banlist.banlist.listItem.network.netType')" :span="6">
       {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>
     <a-descriptions-item :label="t('page.banlist.banlist.listItem.location')" :span="12">
@@ -127,7 +108,10 @@ import CountryFlag from './countryFlag.vue'
 import type { BanList } from '@/api/model/banlist'
 import { useResponsiveState } from '@arco-design/web-vue/es/grid/hook/use-responsive-state'
 import { useI18n } from 'vue-i18n'
+import { Message } from '@arco-design/web-vue'
 import { ref } from 'vue'
+import { unbanIP } from '@/service/banList'
+import AsyncMethod from '@/components/asyncMethod.vue'
 
 const { t, d } = useI18n()
 defineProps<{
@@ -139,6 +123,19 @@ const descriptionLayout = useResponsiveState(
   }),
   0
 )
+const handleUnban = async (address: string) => {
+  const result = await unbanIP(new Array(address))
+  let count = 0;
+  if (result.count) {
+    count = result.count;
+  }
+  if (count < 1) {
+    Message.error(t('page.banlist.banlist.listItem.unbanUnexcepted'))
+  } else {
+    Message.success(t('page.banlist.banlist.listItem.unbanSuccess', { count: count }))
+  }
+  return true
+}
 </script>
 
 <style scoped>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -83,10 +83,9 @@
         </a-tooltip>
       </a-space>
     </a-descriptions-item>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.reserveDNSLookup')" :span="6">
+    <a-descriptions-item v-if="item.banMetadata.reverseLookup != 'N/A'" :label="t('page.banlist.banlist.listItem.reserveDNSLookup')" :span="6">
       {{ item.banMetadata.reverseLookup }}
     </a-descriptions-item>
-
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.isp"
       :label="t('page.banlist.banlist.listItem.network.isp')"
@@ -108,6 +107,11 @@
           {{ item.banMetadata.torrent.name }}
         </a-typography-text>
       </a-tooltip>
+    </a-descriptions-item>
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.rule')" :span="12">
+      <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">
+        {{ item.banMetadata.rule }}
+      </a-typography-text>
     </a-descriptions-item>
     <a-descriptions-item :label="t('page.banlist.banlist.listItem.reason')" :span="12">
       <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -19,11 +19,13 @@
           </a-typography-text>
         </a-tooltip>
         <AsyncMethod once :async-fn="() => handleUnban(item.banMetadata.peer.address.ip)" v-slot="{ run, loading }">
+          <div class="unban-button-container"> <!--这里按钮应该挪到右边去，不过试了 flex 之类的属性，挪不过去，那就先这样了margin-left: auto;-->
           <a-tooltip :content="t('page.banlist.banlist.listItem.unban')">
-            <a-button shape="circle" :disabled="loading" @click.prevent="run">
-              <icon-delete />
+            <a-button shape="circle" :disabled="loading" @click="run">
+              <icon-close />
             </a-button>
           </a-tooltip>
+        </div>
         </AsyncMethod>
       </a-space>
     </template>
@@ -151,4 +153,5 @@ a {
   color: var(--color-text-1);
   text-decoration: none;
 }
+
 </style>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -57,8 +57,8 @@
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="6"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? '?'" />
-      {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
+      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? t('page.banlist.banlist.listItem.empty')" />
+      {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? t('page.banlist.banlist.listItem.empty')}` }}
       <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
         :hoverable="false"

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -57,7 +57,7 @@
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="4"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.country.iso" />
+      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? '?'" />
       {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
       <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
@@ -73,7 +73,7 @@
     >
       <a-space>
         <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
-        <a-tag :color="getColor(item.banMetadata.geo?.as?.number.toString())">{{
+        <a-tag :color="getColor((item.banMetadata.geo?.as?.number ?? 0).toString())">{{
           item.banMetadata.geo?.as?.number
         }}</a-tag>
         <a-tooltip

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -26,39 +26,31 @@
         </a-tooltip>
       </a-space>
     </template>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.banTime')" :span="4">
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.banTime')" :span="6">
       {{ d(item.banMetadata.banAt, 'long') }}
     </a-descriptions-item>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.expireTime')" :span="4">
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.expireTime')" :span="6">
       {{ d(item.banMetadata.unbanAt, 'long') }}
     </a-descriptions-item>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.snapshot')" :span="4">
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.snapshot')" :span="6">
       <icon-arrow-up class="green" />
       {{ formatFileSize(item.banMetadata.peer.uploaded) }}
       <icon-arrow-down class="red" />
       {{ formatFileSize(item.banMetadata.peer.downloaded) }}
       - {{ (item.banMetadata.peer.progress * 100).toFixed(2) }}%
     </a-descriptions-item>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.location')" :span="12">
-      <!-- 这里非常离奇，只要用了a-typography-text就会被下面一行覆盖，怀疑框架有毛病 -->
-      <a-tooltip :content="item.banMetadata.torrent.hash">
-        <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">
-          {{ item.banMetadata.torrent.name }}
-        </a-typography-text>
-      </a-tooltip>
-    </a-descriptions-item>
-    <a-descriptions-item :label="t('page.banlist.banlist.listItem.reason')" :span="12">
-      <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">
-        {{ item.banMetadata.description }}
-      </a-typography-text>
-    </a-descriptions-item>
+
     <a-descriptions-item
       v-if="item.banMetadata.geo"
       :label="t('page.banlist.banlist.listItem.geo')"
       :span="6"
     >
-      <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? t('page.banlist.banlist.listItem.empty')" />
-      {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? t('page.banlist.banlist.listItem.empty')}` }}
+      <CountryFlag
+        :iso="item.banMetadata.geo?.country?.iso ?? t('page.banlist.banlist.listItem.empty')"
+      />
+      {{
+        `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? t('page.banlist.banlist.listItem.empty')}`
+      }}
       <a-link
         :href="`https://uri.amap.com/marker?position=${item.banMetadata.geo?.city?.location?.longitude},${item.banMetadata.geo?.city?.location?.latitude}`"
         :hoverable="false"
@@ -91,11 +83,7 @@
         </a-tooltip>
       </a-space>
     </a-descriptions-item>
-    <a-descriptions-item
-      v-if="item.banMetadata.reverseLookup !== 'N/A'"
-      :label="t('page.banlist.banlist.listItem.reserveDNSLookup')"
-      :span="4"
-    >
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.reserveDNSLookup')" :span="6">
       {{ item.banMetadata.reverseLookup }}
     </a-descriptions-item>
 
@@ -112,6 +100,19 @@
       :span="6"
     >
       {{ item.banMetadata.geo?.network?.netType }}
+    </a-descriptions-item>
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.location')" :span="12">
+      <!-- 这里非常离奇，只要用了a-typography-text就会被下面一行覆盖，怀疑框架有毛病 -->
+      <a-tooltip :content="item.banMetadata.torrent.hash">
+        <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">
+          {{ item.banMetadata.torrent.name }}
+        </a-typography-text>
+      </a-tooltip>
+    </a-descriptions-item>
+    <a-descriptions-item :label="t('page.banlist.banlist.listItem.reason')" :span="12">
+      <a-typography-text style="margin-bottom: 0" :ellipsis="{ showTooltip: true }">
+        {{ item.banMetadata.description }}
+      </a-typography-text>
     </a-descriptions-item>
   </a-descriptions>
 </template>

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -10,13 +10,13 @@
           ? item.banMetadata.peer.id
           : t('page.banlist.banlist.listItem.empty')
           ">
-          <a-typography-text code>
+          <a-tag>
             {{
               item.banMetadata.peer.clientName
                 ? item.banMetadata.peer.clientName
                 : t('page.banlist.banlist.listItem.empty')
             }}
-          </a-typography-text>
+          </a-tag>
         </a-tooltip>
         <AsyncMethod once :async-fn="() => handleUnban(item.banMetadata.peer.address.ip)" v-slot="{ run, loading }">
           <div class="unban-button-container"> <!--这里按钮应该挪到右边去，不过试了 flex 之类的属性，挪不过去，那就先这样了margin-left: auto;-->

--- a/src/views/banlist/components/banListItem.vue
+++ b/src/views/banlist/components/banListItem.vue
@@ -55,7 +55,7 @@
     <a-descriptions-item
       v-if="item.banMetadata.geo"
       :label="t('page.banlist.banlist.listItem.geo')"
-      :span="4"
+      :span="6"
     >
       <CountryFlag :iso="item.banMetadata.geo?.country?.iso ?? '?'" />
       {{ `${item.banMetadata.geo?.country?.name} ${item.banMetadata.geo?.city?.name ?? ''}` }}
@@ -69,7 +69,7 @@
     <a-descriptions-item
       v-if="item.banMetadata.geo?.as"
       :label="t('page.banlist.banlist.listItem.asn')"
-      :span="4"
+      :span="6"
     >
       <a-space>
         <a-typography-text> {{ item.banMetadata.geo?.as?.organization }}</a-typography-text>
@@ -77,10 +77,13 @@
           item.banMetadata.geo?.as?.number
         }}</a-tag>
         <a-tooltip
-          :content="t('page.banlist.banlist.listItem.asn.subnet') + item.banMetadata.geo?.as?.network?.ipAddress"
+          :content="
+            t('page.banlist.banlist.listItem.asn.subnet') +
+            item.banMetadata.geo?.as?.network?.ipAddress
+          "
         >
           <a-link
-            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.asn?.number}`"
+            :href="`https://2ip.io/analytics/asn-list/?asnId=${item.banMetadata.geo?.as?.number}`"
             :hoverable="false"
           >
             <icon-info-circle />
@@ -95,20 +98,20 @@
     >
       {{ item.banMetadata.reverseLookup }}
     </a-descriptions-item>
-    
+
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.isp"
       :label="t('page.banlist.banlist.listItem.network.isp')"
       :span="6"
     >
-    {{ item.banMetadata.geo?.network?.isp }}
+      {{ item.banMetadata.geo?.network?.isp }}
     </a-descriptions-item>
     <a-descriptions-item
       v-if="item.banMetadata.geo?.network?.netType"
       :label="t('page.banlist.banlist.listItem.network.netType')"
       :span="6"
     >
-    {{ item.banMetadata.geo?.network?.netType }}
+      {{ item.banMetadata.geo?.network?.netType }}
     </a-descriptions-item>
   </a-descriptions>
 </template>

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -12,5 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': 'ASN Subnet: ',
   'page.banlist.banlist.listItem.empty': 'Empty',
+  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.netType': 'Net Type: ',
   'page.banlist.banlist.bottomReached': 'No more data!'
 }

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -7,6 +7,7 @@ export default {
   'page.banlist.banlist.listItem.expireTime': 'Unban Time',
   'page.banlist.banlist.listItem.location': 'Torrent',
   'page.banlist.banlist.listItem.snapshot': 'Snapshot',
+  'page.banlist.banlist.listItem.rule': 'Hit Rule',
   'page.banlist.banlist.listItem.reason': 'Ban Reason',
   'page.banlist.banlist.listItem.geo': 'Geo Location',
   'page.banlist.banlist.listItem.asn': 'ASN',

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -13,6 +13,6 @@ export default {
   'page.banlist.banlist.listItem.asn.subnet': 'ASN Subnet: ',
   'page.banlist.banlist.listItem.empty': 'Empty',
   'page.banlist.banlist.listItem.network.isp': 'ISP',
-  'page.banlist.banlist.listItem.network.net': 'Net',
+  'page.banlist.banlist.listItem.network.netType': 'Net',
   'page.banlist.banlist.bottomReached': 'No more data!'
 }

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -12,7 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': 'ASN Subnet: ',
   'page.banlist.banlist.listItem.empty': 'Empty',
-  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
-  'page.banlist.banlist.listItem.network.netType': 'Net Type: ',
+  'page.banlist.banlist.listItem.network.isp': 'ISP',
+  'page.banlist.banlist.listItem.network.net': 'Net',
   'page.banlist.banlist.bottomReached': 'No more data!'
 }

--- a/src/views/banlist/locale/en-US.ts
+++ b/src/views/banlist/locale/en-US.ts
@@ -15,5 +15,8 @@ export default {
   'page.banlist.banlist.listItem.empty': 'Empty',
   'page.banlist.banlist.listItem.network.isp': 'ISP',
   'page.banlist.banlist.listItem.network.netType': 'Net',
-  'page.banlist.banlist.bottomReached': 'No more data!'
+  'page.banlist.banlist.bottomReached': 'No more data!',
+  'page.banlist.banlist.listItem.unban': 'Unban',
+  'page.banlist.banlist.listItem.unbanUnexcepted': 'No IP address(s) unbanned',
+  'page.banlist.banlist.listItem.unbanSuccess': 'Unbanned {count} IP address(s)'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -12,7 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': '子网：',
   'page.banlist.banlist.listItem.empty': '空',
-  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.isp': 'ISP',
   'page.banlist.banlist.listItem.network.netType': '网络类型: ',
   'page.banlist.banlist.bottomReached': '已经到底啦！'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -7,6 +7,7 @@ export default {
   'page.banlist.banlist.listItem.expireTime': '预计解封时间',
   'page.banlist.banlist.listItem.location': '发现位置',
   'page.banlist.banlist.listItem.snapshot': '封禁快照',
+  'page.banlist.banlist.listItem.rule': '命中规则',
   'page.banlist.banlist.listItem.reason': '封禁原因',
   'page.banlist.banlist.listItem.geo': '地理位置',
   'page.banlist.banlist.listItem.asn': 'ASN',

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -15,5 +15,8 @@ export default {
   'page.banlist.banlist.listItem.empty': '空',
   'page.banlist.banlist.listItem.network.isp': 'ISP',
   'page.banlist.banlist.listItem.network.netType': '网络类型',
-  'page.banlist.banlist.bottomReached': '已经到底啦！'
+  'page.banlist.banlist.bottomReached': '已经到底啦！',
+  'page.banlist.banlist.listItem.unban': '解除封禁',
+  'page.banlist.banlist.listItem.unbanUnexcepted': '没有 IP 地址被成功解除封禁',
+  'page.banlist.banlist.listItem.unbanSuccess': '成功解封 {count} 个 IP 地址'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -12,5 +12,7 @@ export default {
   'page.banlist.banlist.listItem.asn': 'ASN',
   'page.banlist.banlist.listItem.asn.subnet': '子网：',
   'page.banlist.banlist.listItem.empty': '空',
+  'page.banlist.banlist.listItem.network.isp': 'ISP: ',
+  'page.banlist.banlist.listItem.network.netType': '网络类型: ',
   'page.banlist.banlist.bottomReached': '已经到底啦！'
 }

--- a/src/views/banlist/locale/zh-CN.ts
+++ b/src/views/banlist/locale/zh-CN.ts
@@ -13,6 +13,6 @@ export default {
   'page.banlist.banlist.listItem.asn.subnet': '子网：',
   'page.banlist.banlist.listItem.empty': '空',
   'page.banlist.banlist.listItem.network.isp': 'ISP',
-  'page.banlist.banlist.listItem.network.netType': '网络类型: ',
+  'page.banlist.banlist.listItem.network.netType': '网络类型',
   'page.banlist.banlist.bottomReached': '已经到底啦！'
 }

--- a/src/views/dashboard/components/clientStatus.vue
+++ b/src/views/dashboard/components/clientStatus.vue
@@ -47,6 +47,7 @@
     <!-- client 卡片 -->
     <a-col v-else :xs="24" :sm="12" :md="8" :lg="6" v-for="client in data" :key="client.name">
       <ClientStatusCard
+        :disable-remove="data.length === 1"
         :downloader="client"
         @torrent-view-click="() => torrentList?.showModal(client.name)"
         @downloader-deleted="refresh"

--- a/src/views/dashboard/components/clientStatusCard.vue
+++ b/src/views/dashboard/components/clientStatusCard.vue
@@ -81,11 +81,12 @@
       </a-descriptions-item>
 
       <a-descriptions-item :label="t('page.dashboard.clientStatus.card.status')">
-        <a-tooltip :content="t(getStatusSafe(client)[1] + '.info')">
+        <a-tooltip :content="client.lastStatusMessage">
           <a-typography-text :type="getStatusSafe(client)[0]">
             <icon-check-circle-fill v-if="client.lastStatus == ClientStatusEnum.HEALTHY" />
             <icon-close-circle-fill v-if="client.lastStatus == ClientStatusEnum.ERROR" />
-            <icon-exclamation-circle-fill v-if="client.lastStatus == ClientStatusEnum.UNKNOWN" />
+            <icon-question-circle-fill v-if="client.lastStatus == ClientStatusEnum.UNKNOWN" />
+            <icon-exclamation-polygon-fill v-if="client.lastStatus == ClientStatusEnum.NEED_TAKE_ACTION" />
             {{ t(getStatusSafe(client)[1]) }}
           </a-typography-text>
         </a-tooltip>
@@ -142,7 +143,8 @@ const { t } = useI18n()
 const statusMap: Record<ClientStatusEnum, [string, string]> = {
   [ClientStatusEnum.HEALTHY]: ['success', 'page.dashboard.clientStatus.card.status.normal'],
   [ClientStatusEnum.ERROR]: ['warning', 'page.dashboard.clientStatus.card.status.error'],
-  [ClientStatusEnum.UNKNOWN]: ['danger', 'page.dashboard.clientStatus.card.status.unknown']
+  [ClientStatusEnum.UNKNOWN]: ['info', 'page.dashboard.clientStatus.card.status.unknown'],
+  [ClientStatusEnum.NEED_TAKE_ACTION]: ['danger', 'page.dashboard.clientStatus.card.status.need_take_action']
 }
 const props = withDefaults(
   defineProps<{

--- a/src/views/dashboard/components/clientStatusCard.vue
+++ b/src/views/dashboard/components/clientStatusCard.vue
@@ -12,12 +12,29 @@
             <icon-edit />
           </template>
         </a-button>
+        <a-tooltip
+          v-if="props.disableRemove"
+          :content="t('page.dashboard.clientStatus.card.lastDelete')"
+        >
+          <a-button class="edit-btn" status="danger" shape="circle" type="text" disabled>
+            <template #icon>
+              <icon-delete />
+            </template>
+          </a-button>
+        </a-tooltip>
         <a-popconfirm
+          v-else
           :content="t('page.ruleSubscribe.column.deleteConfirm')"
           type="warning"
           @before-ok="handleDelete"
         >
-          <a-button class="edit-btn" status="danger" shape="circle" type="text">
+          <a-button
+            class="edit-btn"
+            status="danger"
+            shape="circle"
+            type="text"
+            :disabled="props.disableRemove"
+          >
             <template #icon>
               <icon-delete />
             </template>
@@ -127,9 +144,13 @@ const statusMap: Record<ClientStatusEnum, [string, string]> = {
   [ClientStatusEnum.ERROR]: ['warning', 'page.dashboard.clientStatus.card.status.error'],
   [ClientStatusEnum.UNKNOWN]: ['danger', 'page.dashboard.clientStatus.card.status.unknown']
 }
-const props = defineProps<{
-  downloader: Downloader
-}>()
+const props = withDefaults(
+  defineProps<{
+    downloader: Downloader
+    disableRemove: boolean
+  }>(),
+  { disableRemove: false }
+)
 
 const emits = defineEmits<{
   (e: 'torrent-view-click', name: string): void

--- a/src/views/dashboard/components/forms/biglybt.vue
+++ b/src/views/dashboard/components/forms/biglybt.vue
@@ -2,7 +2,7 @@
   <a-form-item
     field="config.endpoint"
     :label="t('page.dashboard.editModal.label.endpoint')"
-    :rules="[{ required: true, type: 'url' }]"
+    :rules="[]"
   >
     <a-input v-model="config.endpoint" allow-clear></a-input>
   </a-form-item>

--- a/src/views/dashboard/components/forms/biglybt.vue
+++ b/src/views/dashboard/components/forms/biglybt.vue
@@ -12,7 +12,7 @@
   <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
     <a-radio-group v-model="config.httpVersion">
       <a-radio value="HTTP_1_1">1.1</a-radio>
-      <a-radio value="HTTP_2_0">2.0</a-radio>
+      <a-radio value="HTTP_2">2.0</a-radio>
     </a-radio-group>
     <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
   </a-form-item>

--- a/src/views/dashboard/components/forms/deluge.vue
+++ b/src/views/dashboard/components/forms/deluge.vue
@@ -2,7 +2,7 @@
   <a-form-item
     field="config.endpoint"
     :label="t('page.dashboard.editModal.label.endpoint')"
-    :rules="[{ required: true, type: 'url' }]"
+    :rules="[]"
   >
     <a-input v-model="config.endpoint" allow-clear></a-input>
   </a-form-item>

--- a/src/views/dashboard/components/forms/deluge.vue
+++ b/src/views/dashboard/components/forms/deluge.vue
@@ -27,7 +27,7 @@
   <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
     <a-radio-group v-model="config.httpVersion">
       <a-radio value="HTTP_1_1">1.1</a-radio>
-      <a-radio value="HTTP_2_0">2.0</a-radio>
+      <a-radio value="HTTP_2">2.0</a-radio>
     </a-radio-group>
     <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
   </a-form-item>

--- a/src/views/dashboard/components/forms/qbittorrent.vue
+++ b/src/views/dashboard/components/forms/qbittorrent.vue
@@ -2,7 +2,7 @@
   <a-form-item
     field="config.endpoint"
     :label="t('page.dashboard.editModal.label.endpoint')"
-    :rules="[{ required: true, type: 'url' }]"
+    :rules="[]"
   >
     <a-input v-model="config.endpoint" allow-clear></a-input>
   </a-form-item>

--- a/src/views/dashboard/components/forms/qbittorrent.vue
+++ b/src/views/dashboard/components/forms/qbittorrent.vue
@@ -28,7 +28,7 @@
   <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
     <a-radio-group v-model="config.httpVersion">
       <a-radio value="HTTP_1_1">1.1</a-radio>
-      <a-radio value="HTTP_2_0">2.0</a-radio>
+      <a-radio value="HTTP_2">2.0</a-radio>
     </a-radio-group>
     <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
   </a-form-item>

--- a/src/views/dashboard/components/forms/transmission.vue
+++ b/src/views/dashboard/components/forms/transmission.vue
@@ -2,7 +2,7 @@
   <a-form-item
     field="config.endpoint"
     :label="t('page.dashboard.editModal.label.endpoint')"
-    :rules="[{ required: true, type: 'url' }]"
+    :rules="[]"
   >
     <a-input v-model="config.endpoint" allow-clear></a-input>
   </a-form-item>

--- a/src/views/dashboard/components/forms/transmission.vue
+++ b/src/views/dashboard/components/forms/transmission.vue
@@ -18,7 +18,7 @@
   <a-form-item field="config.httpVersion" :label="t('page.dashboard.editModal.label.httpVersion')">
     <a-radio-group v-model="config.httpVersion">
       <a-radio value="HTTP_1_1">1.1</a-radio>
-      <a-radio value="HTTP_2_0">2.0</a-radio>
+      <a-radio value="HTTP_2">2.0</a-radio>
     </a-radio-group>
     <template #extra>{{ t('page.dashboard.editModal.label.httpVersion.description') }} </template>
   </a-form-item>

--- a/src/views/dashboard/components/peerListModal.vue
+++ b/src/views/dashboard/components/peerListModal.vue
@@ -63,10 +63,10 @@
       </template>
       <template #flags="{ record }">
         <p>
-          {{ record.peer.flags }}
-          <a-tooltip v-if="record.peer.flags">
+          {{ record.peer.flags?.ltStdString }}
+          <a-tooltip v-if="record.peer.flags?.ltStdString">
             <template #content>
-              <p v-for="description in parseFlags(record.peer.flags)" :key="description">
+              <p v-for="description in parseFlags(record.peer.flags?.ltStdString)" :key="description">
                 {{ description }}
               </p>
             </template>

--- a/src/views/dashboard/components/peerListModal.vue
+++ b/src/views/dashboard/components/peerListModal.vue
@@ -12,7 +12,7 @@
     <a-table
       :columns="columns"
       :data="data"
-      :loading="loading"
+      :loading="!loading && !data"
       :virtual-list-props="{ height: 850 }"
       :pagination="false"
     >

--- a/src/views/dashboard/components/torrentListModal.vue
+++ b/src/views/dashboard/components/torrentListModal.vue
@@ -12,7 +12,7 @@
     <a-table
       :columns="columns"
       :data="data"
-      :loading="loading"
+      :loading="!loading && !data"
       :pagination="{ pageSize: 5, baseSize: 4, bufferSize: 1 }"
     >
       <template #name="{ record }">

--- a/src/views/dashboard/locale/en-US.ts
+++ b/src/views/dashboard/locale/en-US.ts
@@ -5,13 +5,9 @@ export default {
   'page.dashboard.clientStatus.card.status': 'Status',
   'page.dashboard.clientStatus.card.type': 'Type',
   'page.dashboard.clientStatus.card.status.normal': 'Normal',
-  'page.dashboard.clientStatus.card.status.normal.info': 'Status is good',
   'page.dashboard.clientStatus.card.status.error': 'Error',
-  'page.dashboard.clientStatus.card.status.error.info':
-    'Error occurred when communicating with the client, please check the log file',
   'page.dashboard.clientStatus.card.status.unknown': 'Unknown',
-  'page.dashboard.clientStatus.card.status.unknown.info':
-    'PeerBanHelper may not have communicated with this client yet',
+  'page.dashboard.clientStatus.card.status.need_take_action': 'Need Take Action',
   'page.dashboard.clientStatus.card.status.torrentNumber': 'Active Torrents',
   'page.dashboard.clientStatus.card.status.peerNumber': 'Connected Peers',
   'page.dashboard.clientStatus.card.lastDelete': 'Last downloader cannot be deleted',

--- a/src/views/dashboard/locale/en-US.ts
+++ b/src/views/dashboard/locale/en-US.ts
@@ -14,6 +14,7 @@ export default {
     'PeerBanHelper may not have communicated with this client yet',
   'page.dashboard.clientStatus.card.status.torrentNumber': 'Active Torrents',
   'page.dashboard.clientStatus.card.status.peerNumber': 'Connected Peers',
+  'page.dashboard.clientStatus.card.lastDelete': 'Last downloader cannot be deleted',
   'page.dashboard.statics.currentStatus': 'Current Status',
   'page.dashboard.statics.checked': 'Total checked',
   'page.dashboard.statics.times': 'times',

--- a/src/views/dashboard/locale/zh-CN.ts
+++ b/src/views/dashboard/locale/zh-CN.ts
@@ -10,6 +10,7 @@ export default {
   'page.dashboard.clientStatus.card.status.error.info': '与客户端通信时出错，请检查日志文件',
   'page.dashboard.clientStatus.card.status.unknown': '未知',
   'page.dashboard.clientStatus.card.status.unknown.info': 'PeerBanHelper 可能还没有与此客户端通信',
+  'page.dashboard.clientStatus.card.status.need_take_action': '需要采取行动',
   'page.dashboard.clientStatus.card.status.torrentNumber': '活动种子数',
   'page.dashboard.clientStatus.card.status.peerNumber': '已连接的Peers',
   'page.dashboard.clientStatus.card.lastDelete': '最后一个下载器不能被删除',

--- a/src/views/dashboard/locale/zh-CN.ts
+++ b/src/views/dashboard/locale/zh-CN.ts
@@ -12,6 +12,7 @@ export default {
   'page.dashboard.clientStatus.card.status.unknown.info': 'PeerBanHelper 可能还没有与此客户端通信',
   'page.dashboard.clientStatus.card.status.torrentNumber': '活动种子数',
   'page.dashboard.clientStatus.card.status.peerNumber': '已连接的Peers',
+  'page.dashboard.clientStatus.card.lastDelete': '最后一个下载器不能被删除',
   'page.dashboard.statics.currentStatus': '当前状态',
   'page.dashboard.statics.checked': '共检查',
   'page.dashboard.statics.times': '次',

--- a/src/views/rule-subscribe/components/editRuleItemModal.vue
+++ b/src/views/rule-subscribe/components/editRuleItemModal.vue
@@ -95,7 +95,7 @@ const handleBeforeOk = async () => {
   if (!newItem.value) {
     // edit
     const result = await UpdateRuleItem(form)
-    if (result.code !== 200) {
+    if (result.code !== 200 && result.code !== 201) {
       Message.error(result.message)
       return true
     }


### PR DESCRIPTION
support v5 api : https://github.com/PBH-BTN/PeerBanHelper/pull/220
preview: https://v2.pbh-fe.pages.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to unban IPs directly from the ban list.
  - Enhanced ban list item display with new network-related information and reverse DNS lookup.

- **Bug Fixes**
  - Corrected file size formatting to handle cases where bytes equal -1.
  
- **Localization**
  - Added new translations for network-related items, unbanning actions, and additional messages in both English and Chinese locales.

- **UI Improvements**
  - Updated displayed information in the ban list component, including country, city, ISP, and network type details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->